### PR TITLE
Fix presale calculations

### DIFF
--- a/contracts/CrowdsaleController/CrowdsaleController.sol
+++ b/contracts/CrowdsaleController/CrowdsaleController.sol
@@ -217,12 +217,11 @@ contract CrowdsaleController {
         constant
         returns (uint256)
     {   
-        // uint256 reverseDutchValuation = (100000000 * 10 ** 18/omegaToken.balanceOf(dutchAuction) * 625000*10**18);
-        // uint256 reverseDutchValuationWithPremium =(reverseDutchValuation * 3) / 4;
-        // uint256 valueCap = exchangeRateInWei * 250000000; // 250 million USD in wei
-        // uint256 presaleCap = exchangeRateInWei * 5000000; // 5 million USD in wei
-        // return omegaToken.totalSupply() * presaleCap/min256(valueCap, reverseDutchValuationWithPremium);
-        return omegaToken.totalSupply().mul(exchangeRateInWei).mul(5000000)/min256(exchangeRateInWei.mul(MAIN_SALE_VALUE_CAP),((100000000 * 10 ** 18/omegaToken.balanceOf(dutchAuction) * 625000*10**18 * 3).div(4)));
+        // uint256 minimumAmountOfPresaleTokens = 2000000*10**18;
+        // uint256 reverseDutchValuation = 25000000*10**36/omegaToken.balanceOf(dutchAuction)
+        // uint256 reverseDutchValuationWithPresaleDiscount = (reverseDutchValuation * 3) / 4;
+        // uint256 presaleCap = 5000000; // 5 million USD
+      return max256(2000000*10**18, 5000000*10**36/(25000000*10**36/omegaToken.balanceOf(dutchAuction)).mul(3).div(4));
     }
 
     /*
@@ -238,15 +237,15 @@ contract CrowdsaleController {
         FinalizeSale(endTime);
     }
 
-    /// @dev Calculates the minimum between two numbers
+    /// @dev Calculates the maximum between two numbers
     /// @param a The first number
     /// @param b The second number
-    function min256(uint256 a, uint256 b) 
+    function max256(uint256 a, uint256 b) 
         private 
         constant 
         returns (uint256) 
     {
-        return a < b ? a : b;
+        return a > b ? a : b;
     }
 
     function setupPresaleClaim()

--- a/tests/python/crowdsale_controller/test_crowdsale_controller_math.py
+++ b/tests/python/crowdsale_controller/test_crowdsale_controller_math.py
@@ -5,6 +5,8 @@ class TestContract(AbstractTestContracts):
     run test with python -m unittest tests.python.crowdsale_controller.test_crowdsale_controller_math
     """
 
+    BLOCKS_PER_DAY = 6000
+
     def __init__(self, *args, **kwargs):
         super(TestContract, self).__init__(*args, **kwargs)
 
@@ -41,6 +43,8 @@ class TestContract(AbstractTestContracts):
         # Start auction
         start_auction_data = self.dutch_auction.translator.encode('startAuction', [])
         self.multisig_wallet.submitTransaction(self.dutch_auction.address, 0, start_auction_data, sender=keys[wa_1])
+        # Record current state
+        snapshot = self.s.snapshot()
         # Math
         # Sets up dutch auction total received for presale math
         bidder_1 = 4
@@ -48,3 +52,30 @@ class TestContract(AbstractTestContracts):
         self.dutch_auction.bid(sender=keys[bidder_1], value=total_received)
         # Check that the presale token supply is calculated correctly
         self.assertEqual(int(self.crowdsale_controller.calcPresaleTokenSupply()), 2000000 * 10**18)
+        self.s.revert(snapshot)
+        self.s.head_state.block_number += self.BLOCKS_PER_DAY *5-1000
+        total_received = 62500 * 10**18
+        self.dutch_auction.bid(sender=keys[bidder_1], value=total_received)
+        self.dutch_auction.updateStage()
+        # Check that the presale token supply is calculated correctly
+        self.assertEqual(int(self.crowdsale_controller.calcPresaleTokenSupply()), 3234115138592752785592995)
+        self.s.revert(snapshot)
+        self.s.head_state.block_number += self.BLOCKS_PER_DAY *3
+        total_received = 32500 * 10**18
+        self.dutch_auction.bid(sender=keys[bidder_1], value=total_received)
+        self.dutch_auction.updateStage()
+        # Check that the presale token supply is calculated correctly
+        self.assertEqual(int(self.crowdsale_controller.calcPresaleTokenSupply()), 6320000000000000007381760)
+        self.s.revert(snapshot)
+        self.s.head_state.block_number += self.BLOCKS_PER_DAY *3
+        total_received = 62500 * 10**18
+        self.dutch_auction.bid(sender=keys[bidder_1], value=total_received)
+        self.dutch_auction.updateStage()
+        # Check that the presale token supply is calculated correctly
+        self.assertEqual(int(self.crowdsale_controller.calcPresaleTokenSupply()), 2000000*10**18)
+        self.s.revert(snapshot)
+        self.s.head_state.block_number += self.BLOCKS_PER_DAY * 5 -10
+        self.dutch_auction.bid(sender=keys[bidder_1], value=62500 * 10**18)
+        self.dutch_auction.updateStage()
+        # Check that the presale token supply is calculated correctly
+        self.assertEqual(int(self.crowdsale_controller.calcPresaleTokenSupply()), 6260266622642294731968069)

--- a/tests/python/crowdsale_controller/test_crowdsale_controller_math.py
+++ b/tests/python/crowdsale_controller/test_crowdsale_controller_math.py
@@ -53,6 +53,27 @@ class TestContract(AbstractTestContracts):
         # Check that the presale token supply is calculated correctly
         self.assertEqual(int(self.crowdsale_controller.calcPresaleTokenSupply()), 2000000 * 10**18)
         self.s.revert(snapshot)
+        self.s.head_state.block_number += self.BLOCKS_PER_DAY *3
+        total_received = 62500 * 10**18
+        self.dutch_auction.bid(sender=keys[bidder_1], value=total_received)
+        self.dutch_auction.updateStage()
+        # Check that the presale token supply is calculated correctly
+        self.assertEqual(int(self.crowdsale_controller.calcPresaleTokenSupply()), 2000000*10**18)
+        self.s.revert(snapshot)
+        self.s.head_state.block_number += self.BLOCKS_PER_DAY * 5 - 1500
+        self.dutch_auction.bid(sender=keys[bidder_1], value=62500 * 10**18)
+        self.dutch_auction.updateStage()
+        # Check that the presale token supply is calculated correctly
+        self.assertEqual(int(self.crowdsale_controller.calcPresaleTokenSupply()), 2599485861182520710363923)
+        self.s.revert(snapshot)
+        self.s.head_state.block_number += self.BLOCKS_PER_DAY *1
+        total_received = 20000 * 10**18
+        self.dutch_auction.bid(sender=keys[bidder_1], value=total_received)
+        self.s.head_state.block_number += self.BLOCKS_PER_DAY *4
+        self.dutch_auction.updateStage()
+        # Check that the presale token supply is calculated correctly
+        self.assertEqual(int(self.crowdsale_controller.calcPresaleTokenSupply()), 2022400000000002847539200)
+        self.s.revert(snapshot)
         self.s.head_state.block_number += self.BLOCKS_PER_DAY *5-1000
         total_received = 62500 * 10**18
         self.dutch_auction.bid(sender=keys[bidder_1], value=total_received)
@@ -63,16 +84,47 @@ class TestContract(AbstractTestContracts):
         self.s.head_state.block_number += self.BLOCKS_PER_DAY *3
         total_received = 32500 * 10**18
         self.dutch_auction.bid(sender=keys[bidder_1], value=total_received)
+        self.s.head_state.block_number += self.BLOCKS_PER_DAY *2
         self.dutch_auction.updateStage()
         # Check that the presale token supply is calculated correctly
-        self.assertEqual(int(self.crowdsale_controller.calcPresaleTokenSupply()), 6320000000000000007381760)
+        self.assertEqual(int(self.crowdsale_controller.calcPresaleTokenSupply()), 3286400000000004629245124)
+        self.s.revert(snapshot)
+        self.s.head_state.block_number += self.BLOCKS_PER_DAY * 5 -10
+        self.dutch_auction.bid(sender=keys[bidder_1], value=30500 * 10**18)
+        self.s.head_state.block_number += 10
+        self.dutch_auction.updateStage()
+        # Check that the presale token supply is calculated correctly
+        self.assertEqual(int(self.crowdsale_controller.calcPresaleTokenSupply()), 3084160000000004342777963)
         self.s.revert(snapshot)
         self.s.head_state.block_number += self.BLOCKS_PER_DAY *3
-        total_received = 62500 * 10**18
+        total_received = 32500 * 10**18
         self.dutch_auction.bid(sender=keys[bidder_1], value=total_received)
+        self.s.head_state.block_number += self.BLOCKS_PER_DAY *2
         self.dutch_auction.updateStage()
         # Check that the presale token supply is calculated correctly
-        self.assertEqual(int(self.crowdsale_controller.calcPresaleTokenSupply()), 2000000*10**18)
+        self.assertEqual(int(self.crowdsale_controller.calcPresaleTokenSupply()), 3286400000000004629245124)
+        self.s.revert(snapshot)
+        self.s.head_state.block_number += self.BLOCKS_PER_DAY *2
+        total_received = 40500 * 10**18
+        self.dutch_auction.bid(sender=keys[bidder_1], value=total_received)
+        self.s.head_state.block_number += self.BLOCKS_PER_DAY *3
+        self.dutch_auction.updateStage()
+        # Check that the presale token supply is calculated correctly
+        self.assertEqual(int(self.crowdsale_controller.calcPresaleTokenSupply()), 4095360000000005767136537)
+        self.s.revert(snapshot)
+        self.s.head_state.block_number += self.BLOCKS_PER_DAY * 5 - 500
+        self.dutch_auction.bid(sender=keys[bidder_1], value=62500 * 10**18)
+        self.dutch_auction.updateStage()
+        # Check that the presale token supply is calculated correctly
+        self.assertEqual(int(self.crowdsale_controller.calcPresaleTokenSupply()), 4278702397743304433741783)
+        self.s.revert(snapshot)
+        self.s.head_state.block_number += self.BLOCKS_PER_DAY *1
+        total_received = 55000 * 10**18
+        self.dutch_auction.bid(sender=keys[bidder_1], value=total_received)
+        self.s.head_state.block_number += self.BLOCKS_PER_DAY *4
+        self.dutch_auction.updateStage()
+        # Check that the presale token supply is calculated correctly
+        self.assertEqual(int(self.crowdsale_controller.calcPresaleTokenSupply()), 5561600000000007834669522)
         self.s.revert(snapshot)
         self.s.head_state.block_number += self.BLOCKS_PER_DAY * 5 -10
         self.dutch_auction.bid(sender=keys[bidder_1], value=62500 * 10**18)

--- a/tests/python/dutch_auction/test_dutch_auction.py
+++ b/tests/python/dutch_auction/test_dutch_auction.py
@@ -30,7 +30,6 @@ class TestContract(AbstractTestContracts):
         # Create dutch auction with ceiling of 2 billion and price factor of 200,000
         self.dutch_auction = self.create_contract('DutchAuction/DutchAuction.sol',
                                                   params=(self.multisig_wallet.address, 2000 * 10 ** 18, 200000))
-        # import pdb; pdb.set_trace()
         # Create crowdsale controller
         self.crowdsale_controller = self.create_contract('CrowdsaleController/CrowdsaleController.sol', 
                                                         params=(self.multisig_wallet.address, self.dutch_auction, 2500000000000000))
@@ -71,7 +70,7 @@ class TestContract(AbstractTestContracts):
         self.s.head_state.block_number = 3
         self.assertEqual(self.dutch_auction.calcTokenPrice(), int(self.PRICE_FACTOR))
         bidder_1 = 0
-        value_1 = 20000 * 10**18  # 30k Ether
+        value_1 = 20000 * 10**18  # 20k Ether
         self.dutch_auction.bid(sender=keys[bidder_1], value=value_1)
         self.assertEqual(self.dutch_auction.calcStopPrice(), int(self.PRICE_FACTOR - decrease_per_day * 5))
         # A few blocks later

--- a/tests/python/presale/test_presale.py
+++ b/tests/python/presale/test_presale.py
@@ -30,7 +30,6 @@ class TestContract(AbstractTestContracts):
 
         self.assertEqual(self.presale.MAX_PERCENT_OF_PRESALE(), 100 * 10 **18);
         self.assertEqual(self.presale.percentOfPresaleSold(), 0);
-        # import pdb; pdb.set_trace()
         self.assertEqual(utils.remove_0x_head(self.presale.crowdsaleController()), crowdsale_controller_address.hex())
         
         # Buyer can buy presale tokens as soon as it's initialized

--- a/tests/python/wallet/test_multisig_wallet.py
+++ b/tests/python/wallet/test_multisig_wallet.py
@@ -31,7 +31,6 @@ class TestContract(AbstractTestContracts):
         self.assertTrue(self.multisig_wallet.isOwner(accounts[wa_3]))
         self.assertEqual(utils.remove_0x_head(self.multisig_wallet.owners(2)), accounts[wa_3].hex())
         self.assertEqual(self.multisig_wallet.required(), required_accounts)
-        # import pdb; pdb.set_trace()
         self.assertEqual(self.multisig_wallet.getOwners(), ['0x'+accounts[wa_1].hex(), '0x'+accounts[wa_2].hex(), '0x'+accounts[wa_3].hex()])
         # Create ABIs
         multisig_abi = self.multisig_wallet.translator
@@ -46,7 +45,6 @@ class TestContract(AbstractTestContracts):
         self.assertRaises(TransactionFailed, self.multisig_wallet.submitTransaction, self.multisig_wallet.address, 0,
                           add_owner_data, sender=keys[0])
         # Wallet owner tries to submit transaction with destination address 0 but fails. 0 address is not allowed.
-        # import pdb; pdb.set_trace()
         # self.assertRaises(
         #     TransactionFailed, self.multisig_wallet.submitTransaction, 0, 0, add_owner_data, sender=keys[wa_1])
         self.s.mine()


### PR DESCRIPTION
This PR fixes and simplifies the presale percentage calculation. It is notable that `min()` has been changed to `max()`. This also improves the test coverage for those calculations.